### PR TITLE
CMake build script

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,10 +9,10 @@ if(ANDROID)
     set(CMAKE_C_FLAGS  "${CMAKE_C_FLAGS} -Wall -Wextra -std=gnu99")
     include_directories(${LIB_ANCILLARY_DIR})
 
-    add_definitions(-DBADVPN_THREADWORK_USE_PTHREAD)
-    add_definitions(-DBADVPN_LINUX -DBADVPN_BREACTOR_BADVPN -D_GNU_SOURCE -DANDROID -D__ANDROID__)
-    add_definitions(-DBADVPN_USE_SELFPIPE -DBADVPN_USE_EPOLL)
+    add_definitions(-DBADVPN_THREADWORK_USE_PTHREAD -DBADVPN_LINUX -DBADVPN_BREACTOR_BADVPN -D_GNU_SOURCE)
+    add_definitions(-DBADVPN_USE_SIGNALFD -DBADVPN_USE_EPOLL)
     add_definitions(-DBADVPN_LITTLE_ENDIAN -DBADVPN_THREAD_SAFE)
+    add_definitions(-DNDEBUG -DANDROID -D__ANDROID__)
 endif()
 
 set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/modules")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,20 @@
 cmake_minimum_required(VERSION 2.8)
 project(BADVPN C)
 
+if(ANDROID)
+    set(BUILD_NOTHING_BY_DEFAULT 1 CACHE INTERNAL "BUILD_NOTHING_BY_DEFAULT" )
+    set(BUILD_TUN2SOCKS 1 CACHE INTERNAL "BUILD_TUN2SOCKS" )
+    set(HAVE_SYSLOG_H 1 CACHE INTERNAL "HAVE_SYSLOG_H" )
+
+    set(CMAKE_C_FLAGS  "${CMAKE_C_FLAGS} -Wall -Wextra -std=gnu99")
+    include_directories(${LIB_ANCILLARY_DIR})
+
+    add_definitions(-DBADVPN_THREADWORK_USE_PTHREAD)
+    add_definitions(-DBADVPN_LINUX -DBADVPN_BREACTOR_BADVPN -D_GNU_SOURCE -DANDROID -D__ANDROID__)
+    add_definitions(-DBADVPN_USE_SELFPIPE -DBADVPN_USE_EPOLL)
+    add_definitions(-DBADVPN_LITTLE_ENDIAN -DBADVPN_THREAD_SAFE)
+endif()
+
 set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/modules")
 
 include(GNUInstallDirs)
@@ -169,7 +183,9 @@ else ()
     add_definitions(-DBADVPN_THREADWORK_USE_PTHREAD)
     add_definitions(-DBADVPN_THREAD_SAFE=1)
 
+    if(NOT ANDROID)
     link_libraries(rt pthread)
+    endif()
 
     if (EMSCRIPTEN)
         add_definitions(-DBADVPN_EMSCRIPTEN)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,7 +12,7 @@ if(ANDROID)
     add_definitions(-DBADVPN_THREADWORK_USE_PTHREAD -DBADVPN_LINUX -DBADVPN_BREACTOR_BADVPN -D_GNU_SOURCE)
     add_definitions(-DBADVPN_USE_SIGNALFD -DBADVPN_USE_EPOLL)
     add_definitions(-DBADVPN_LITTLE_ENDIAN -DBADVPN_THREAD_SAFE)
-    add_definitions(-DNDEBUG -DANDROID -D__ANDROID__)
+    add_definitions(-DNDEBUG)
 endif()
 
 set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/modules")

--- a/tun2socks/CMakeLists.txt
+++ b/tun2socks/CMakeLists.txt
@@ -1,3 +1,12 @@
+if(ANDROID)
+
+    include_directories(${LIB_ANCILLARY_DIR})
+    add_executable(tun2socks tun2socks.c SocksUdpGwClient.c)
+    target_link_libraries(tun2socks base system flow tuntap lwip socksclient udpgw_client ancillary log)
+    set_target_properties(tun2socks PROPERTIES PREFIX "lib" SUFFIX ".so")
+
+else()
+
 add_executable(badvpn-tun2socks
     tun2socks.c
     SocksUdpGwClient.c
@@ -13,3 +22,5 @@ install(
     FILES badvpn-tun2socks.8
     DESTINATION ${CMAKE_INSTALL_MANDIR}/man8
 )
+
+endif()

--- a/tun2socks/CMakeLists.txt
+++ b/tun2socks/CMakeLists.txt
@@ -2,7 +2,7 @@ if(ANDROID)
 
     include_directories(${LIB_ANCILLARY_DIR})
     add_executable(tun2socks tun2socks.c SocksUdpGwClient.c)
-    target_link_libraries(tun2socks base system flow tuntap lwip socksclient udpgw_client ancillary log)
+    target_link_libraries(tun2socks base system flow tuntap lwip socksclient udpgw_client ancillary dl log)
     set_target_properties(tun2socks PROPERTIES PREFIX "lib" SUFFIX ".so")
 
 else()


### PR DESCRIPTION
Add CMake build supporting in Android for tun2socks component.

Now we can create a CMakeLists.txt file to use it.
```
cmake_minimum_required(VERSION 3.4)
project("myapplication")
add_subdirectory(libancillary)
add_subdirectory(badvpn)
```
Once the script running finished, we get the file `libtun2socks.so`.